### PR TITLE
feat: use nedb uid function for ids

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const crypto = require('crypto')
+const uid = require('nedb/lib/customUtils')
+
 
 const bufferEncoding = 'base64'
 const idKey = '_id'
@@ -129,13 +130,10 @@ function castValue (value) {
 
 
 /**
- * Generate base64 string from 15 bytes of strong randomness (this is 2 less
- * bits of entropy than UUID version 4). It is ideal for the length of the
- * input to be divisible by 3, since base64 expands the binary input by
- * exactly 1 byte for every 3 bytes, and adds padding length of modulus 3.
+ * Defer to using the uid function provided by NEDB.
  *
  * @return {String}
  */
 function generateId () {
-  return crypto.randomBytes(15).toString(bufferEncoding)
+  return uid(16)
 }


### PR DESCRIPTION
Rather than generating non web safe ids as described in issue #7 we are now using the nedb uid function. 

I'm super flexible to how we do this so feel free to request changes.