### PR TITLE
fix: reference the actual uid function

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const uid = require('nedb/lib/customUtils')
+const uid = require('nedb/lib/customUtils').uid
 
 
 const bufferEncoding = 'base64'


### PR DESCRIPTION
My previous pull request wasn't picking up the actual `uid` function from `nedb`.